### PR TITLE
ZETA-6470: Fix logic so it preserves existing package json

### DIFF
--- a/src/npm/npm-install/npm-install.spec.ts
+++ b/src/npm/npm-install/npm-install.spec.ts
@@ -3,12 +3,18 @@ import { morphCommand } from "../../command-morph/command-morph";
 describe('npmInstall', () => {
   it('should return npm install with needed codemod', async() => {
     const npmInstallCommandText = 'npm install apollo-angular';
-    const mockPackageJson = {name: 'hello', dependencies: {}};
+    const mockPackageJson = {
+      name: 'hello', 
+      dependencies: {
+        "angular": "16.0.0"
+      }
+    };
     const stringifiedMockPackageJson = JSON.stringify(mockPackageJson);
     const result = await morphCommand(npmInstallCommandText, stringifiedMockPackageJson);
     const expected = `{
   "name": "hello",
   "dependencies": {
+    "angular": "16.0.0",
     "apollo-angular": "5.0.0"
   }
 }`;

--- a/src/npm/npm-install/npm-install.ts
+++ b/src/npm/npm-install/npm-install.ts
@@ -5,6 +5,8 @@ import {morphCode, EditInput} from "@codemorph/core";
 export async function npmInstallCodemorph(commandText: string, packageJsonString: string): Promise<string> {
   const packageName = extractPackageName(commandText);
   const {name, version} = await getNameAndVersion(packageName);
+  const packageJsonParsed = JSON.parse(packageJsonString);
+  const packageJsonDependencies = packageJsonParsed && packageJsonParsed.dependencies;
 
   const editInput: EditInput = {
     fileType: 'json',
@@ -14,7 +16,10 @@ export async function npmInstallCodemorph(commandText: string, packageJsonString
       {
         nodeType: 'editJson' as any,
         valueToModify: '/dependencies',
-        codeBlock: {[name]: version}
+        codeBlock: {
+          ...packageJsonDependencies,
+          [name]: version
+        }
       }
     ]
   }


### PR DESCRIPTION
Was removing prior dependencies with new dependencies. This has now been fixed