### PR TITLE
ZETA-6578: Update logic works with ampersands too.

### DIFF
--- a/src/utils/command-search/command-search.spec.ts
+++ b/src/utils/command-search/command-search.spec.ts
@@ -43,6 +43,12 @@ describe('WordSearch', () => {
       const result = extractPackageNames(sampleCommand);
       expect(result).toEqual(['apollo-angular@^3.0.1', 'react']);
     });
+
+    it('should extract all package names from a command if uses && syntax', () => {
+      const sampleCommand = 'npm install apollo-angular@^3.0.1 --save && react --save';
+      const result = extractPackageNames(sampleCommand);
+      expect(result).toEqual(['apollo-angular@^3.0.1', 'react']);
+    });
   })
   
 });

--- a/src/utils/command-search/command-search.ts
+++ b/src/utils/command-search/command-search.ts
@@ -11,11 +11,24 @@ export function getSecondWordOfCommand(commandText: string): NpmCommandMorph {
   return words[1] as unknown as NpmCommandMorph;
 } 
 
+function containsDoubleAmpersand(input: string): boolean {
+  const regex = /&&/;
+  return regex.test(input);
+}
+
 export function extractPackageNames(commandText: string): string[] {
-  const commandTextCleaned = commandText.replace('npm', '')
-    .replace('install', '').replace('--save', '').replace('--save-dev', '')
-    .replace(';', '').trim();
-  return commandTextCleaned.split(' ');
+  const commandTextCleaned = commandText.replace(/npm/g, '')
+    .replace(/install/g, '')
+    .replace(/--save/g, '')
+    .replace(/--save-dev/g, '')
+    .replace(/;/g, '')
+    .trim();
+  
+  if(containsDoubleAmpersand(commandTextCleaned)) {
+    return commandTextCleaned.split('&&').map(packageName => packageName.trim());
+  } else {
+    return commandTextCleaned.split(' ');
+  }
 }
 
 


### PR DESCRIPTION
npm install now works with ampersands e.g. 

'npm install apollo-angular@^3.0.1 --save && react --save'